### PR TITLE
use salt start with 0 instead of binding to deploy address(msg.sender)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ forge script --broadcast -vvvv --rpc-url {rpc_url} \
 
 |Mainnet Chain|Address|
 |---|---|
-|Ethereum|[0x00000000009706556bfd041ed3ea54aa406a7e60](https://etherscan.io/address/0x00000000009706556bfd041ed3ea54aa406a7e60)|
+|Ethereum|[0x000000000374800E799771196BF826cb7e7511a2](https://etherscan.io/address/0x000000000374800E799771196BF826cb7e7511a2)|
 
 |Testnet Chain|Address|
 |---|---|
-|Ethereum (Goerli)|[0x00000000009706556bfd041ed3ea54aa406a7e60](https://goerli.etherscan.io/address/0x00000000009706556bfd041ed3ea54aa406a7e60)|
+|Ethereum (Goerli)|[0x000000000374800E799771196BF826cb7e7511a2](https://goerli.etherscan.io/address/0x000000000374800E799771196BF826cb7e7511a2)|
 
 If you'd like to get the Primary on another EVM chain, anyone in the community can deploy to the same address and make a PR to add link here.
 

--- a/script/deploy.s.sol
+++ b/script/deploy.s.sol
@@ -20,7 +20,7 @@ interface ImmutableCreate2Factory {
 contract Deploy is Script {
     ImmutableCreate2Factory immutable factory = ImmutableCreate2Factory(0x0000000000FFe8B47B3e2130213B802212439497);
     bytes initCode = type(PrimaryPFP).creationCode;
-    bytes32 salt = 0x200d2620bec53d91689554b041cfb79cd5559a6238cf2f66cad3480002dea0a4;
+    bytes32 salt = 0x0000000000000000000000000000000000000000327b831546a32001f5db6df9;
 
     function run() external {
         vm.startBroadcast();


### PR DESCRIPTION
the containsCaller code here:
https://etherscan.io/address/0x0000000000ffe8b47b3e2130213b802212439497#code

is either start with many zero or start with msg.sender, since we want this code can be deployed by anyone to any layer or chain, we need to make the salt start with zeros.